### PR TITLE
Replace Azure deployment with Docker container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/bin/
+**/obj/
+**/node_modules/
+**/wwwroot/
+.git/
+.github/

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,9 +31,7 @@ jobs:
         images: ghcr.io/${{ github.repository }}
         tags: |
           type=ref,event=branch
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix={{branch}}-
+          type=sha
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -13,49 +13,33 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      if: github.event_name != 'pull_request'
       with:
-        node-version: '24'
-        cache: 'npm'
-        cache-dependency-path: RemotePlan.Server/package-lock.json
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install npm dependencies
-      working-directory: RemotePlan.Server
-      run: npm ci
-
-    - name: Build frontend
-      working-directory: RemotePlan.Server
-      run: npm run build
-
-    - uses: actions/setup-dotnet@v4
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
       with:
-        dotnet-version: '10.0.x'
+        images: ghcr.io/${{ github.repository }}
+        tags: |
+          type=ref,event=branch
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=sha,prefix={{branch}}-
+          type=raw,value=latest,enable={{is_default_branch}}
 
-    - name: Publish .NET app
-      run: dotnet publish RemotePlan.Server/RemotePlan.Server.csproj -c Release -o ./publish
-
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
       with:
-        name: dotnet-app
-        path: ./publish
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    environment: production
-
-    steps:
-    - name: Download artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: dotnet-app
-        path: ./publish
-
-    - name: Deploy to Azure Web App
-      uses: azure/webapps-deploy@v3
-      with:
-        app-name: ${{ vars.AZURE_WEBAPP_NAME }}
-        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        package: ./publish
+        context: .
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build frontend
+FROM node:24-alpine AS frontend-build
+
+WORKDIR /app
+COPY RemotePlan.Server/package*.json ./
+RUN npm ci
+COPY RemotePlan.Server/src ./src
+COPY RemotePlan.Server/webpack.config.js RemotePlan.Server/tsconfig.json ./
+RUN npm run build
+
+# Stage 2: Build .NET backend
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS dotnet-build
+
+WORKDIR /app
+COPY RemotePlan.Server/RemotePlan.Server.csproj .
+RUN dotnet restore
+
+COPY RemotePlan.Server/ .
+COPY --from=frontend-build /app/wwwroot ./wwwroot
+
+RUN dotnet publish -c Release -o /publish
+
+# Stage 3: Runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+
+WORKDIR /app
+COPY --from=dotnet-build /publish .
+
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "RemotePlan.Server.dll"]


### PR DESCRIPTION
## Summary
Replace artifact-based Azure Web App deployment with Docker container build and push to GitHub Container Registry (ghcr.io).

- Multi-stage Dockerfile: Node.js 24 frontend build → .NET 10 backend build → aspnet:10.0 runtime
- GitHub Actions workflow now builds container images on all pushes/PRs (validation only on PRs, push to registry on main merge)
- `.dockerignore` excludes build artifacts for efficient context
- Verified locally and in CI: image builds successfully and app responds on port 8080

## Test plan
- [x] Docker image builds locally (`docker build -t remoteplan .`)
- [x] Container runs and serves app (`docker run -p 8080:8080`)
- [x] GitHub Actions workflow runs on PR — build succeeds
- [ ] Verify image is pushed to ghcr.io on merge to main

🤖 Generated with Claude Code