### PR TITLE
Add multi-platform Docker builds (amd64, arm64)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,6 +38,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
Enable Docker builds for multiple architectures: `linux/amd64` and `linux/arm64`.

This allows the container image to run natively on:
- Standard Linux servers and CI/CD runners (amd64)
- M-series Macs (arm64)
- Windows 11 via Docker Desktop (linux/arm64 or amd64)

Builds both architectures in a single GitHub Actions job using Docker Buildx's cross-platform build capability.

## Test plan
- [x] Workflow updated with platforms configuration
- [ ] Verify workflow builds both architectures on merge to main
- [ ] Confirm arm64 image runs on M-series Mac

🤖 Generated with Claude Code